### PR TITLE
type definitions & name export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+export class Deprecation extends Error {
+  name: "Deprecation";
+}

--- a/index.js
+++ b/index.js
@@ -12,4 +12,4 @@ class Deprecation extends Error {
   }
 }
 
-module.exports = module.exports.Deprecation = Deprecation
+module.exports.Deprecation = Deprecation

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "Log a deprecation message with stack",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "node test.js"
   },

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 
-const Deprecation = require('.')
+const { Deprecation } = require('.')
 
 let deprecation
 function foo () {


### PR DESCRIPTION
This pull request includes a breaking change:
`const Deprecation = require("deprecation")` is now `const { Deprecation } = require("deprecation")`